### PR TITLE
Add extra EC2 labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The exporter can be started with this configuration to query this endpoint local
 ```
 # HELP aws_instance_termination_imminent Instance is about to be terminated
 # TYPE aws_instance_termination_imminent gauge
-aws_instance_termination_imminentt{availability_zone="us-east-1a",hostname="ip-10-23-24-150.ec2.internal",instance_id="i-05f2236177d4ba9ca",instance_type="m4.2xlarge",instance_action="terminate"} 1
+aws_instance_termination_imminent{availability_zone="us-east-1a",hostname="ip-10-23-24-150.ec2.internal",instance_id="i-05f2236177d4ba9ca",instance_type="m4.2xlarge",instance_action="terminate"} 1
 # HELP aws_instance_termination_in Instance will be terminated in
 # TYPE aws_instance_termination_in gauge
 aws_instance_termination_in{availability_zone="us-east-1a",hostname="ip-10-23-24-150.ec2.internal",instance_id="i-05f2236177d4ba9ca",instance_type="m4.2xlarge",instance_action="terminate"} 119.888545

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Prometheus [exporters](https://prometheus.io/docs/instrumenting/writing_exporter
 
 ### Spot instance termination notice
 
-The Termination Notice is accessible to code running on the instance via the instance’s metadata at `http://169.254.169.254/latest/meta-data/spot/termination-time`. This field becomes available when the instance has been marked for termination and will contain the time when a shutdown signal will be sent to the instance’s operating system. 
-At that time, the Spot Instance Request’s bid status will be set to `marked-for-termination.`  
+The Termination Notice is accessible to code running on the instance via the instance’s metadata at `http://169.254.169.254/latest/meta-data/spot/termination-time`. This field becomes available when the instance has been marked for termination and will contain the time when a shutdown signal will be sent to the instance’s operating system.
+At that time, the Spot Instance Request’s bid status will be set to `marked-for-termination.`
 The bid status is accessible via the `DescribeSpotInstanceRequests` API for use by programs that manage Spot bids and instances.
 
 ### Quick start
@@ -55,15 +55,12 @@ The exporter can be started with this configuration to query this endpoint local
 ### Metrics
 
 ```
-# HELP aws_instance_metadata_service_available Metadata service available
-# TYPE aws_instance_metadata_service_available gauge
-aws_instance_metadata_service_available{instance_id="i-0d2aab13057917887"} 1
 # HELP aws_instance_termination_imminent Instance is about to be terminated
 # TYPE aws_instance_termination_imminent gauge
-aws_instance_termination_imminent{instance_action="stop",instance_id="i-0d2aab13057917887"} 1
+aws_instance_termination_imminentt{availability_zone="us-east-1a",hostname="ip-10-23-24-150.ec2.internal",instance_id="i-05f2236177d4ba9ca",instance_type="m4.2xlarge",instance_action="terminate"} 1
 # HELP aws_instance_termination_in Instance will be terminated in
 # TYPE aws_instance_termination_in gauge
-aws_instance_termination_in{instance_id="i-0d2aab13057917887"} 119.888545
+aws_instance_termination_in{availability_zone="us-east-1a",hostname="ip-10-23-24-150.ec2.internal",instance_id="i-05f2236177d4ba9ca",instance_type="m4.2xlarge",instance_action="terminate"} 119.888545
 ```
 
 ### Default Hollowtrees node exporters associated to alerts:

--- a/metadata.go
+++ b/metadata.go
@@ -11,7 +11,6 @@ import (
 
 type terminationCollector struct {
 	metadataEndpoint     string
-	scrapeSuccessful     *prometheus.Desc
 	terminationIndicator *prometheus.Desc
 	terminationTime      *prometheus.Desc
 }
@@ -21,17 +20,47 @@ type InstanceAction struct {
 	Time   time.Time `json:"time"`
 }
 
+var (
+	labels = []string {
+		"availability_zone",
+		"hostname",
+		"instance_id",
+		"instance_type",
+	}
+)
+
+func (c *terminationCollector) getMetadata(path string) (string, error) {
+	timeout := time.Duration(1 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	url := c.metadataEndpoint + path
+	idResp, err := client.Get(url)
+	if err != nil {
+		log.Errorf("error request metadata from %s: %s", url, err.Error())
+		return "", err
+	}
+	if idResp.StatusCode == 404 {
+		log.Errorf("endpoint %s not found", url)
+		return "", nil
+	}
+	defer idResp.Body.Close()
+	value, _ := ioutil.ReadAll(idResp.Body)
+
+	return string(value), nil
+
+}
+
 func NewTerminationCollector(me string) *terminationCollector {
 	return &terminationCollector{
 		metadataEndpoint:     me,
-		scrapeSuccessful:     prometheus.NewDesc("aws_instance_metadata_service_available", "Metadata service available", []string{"instance_id"}, nil),
-		terminationIndicator: prometheus.NewDesc("aws_instance_termination_imminent", "Instance is about to be terminated", []string{"instance_action", "instance_id"}, nil),
-		terminationTime:      prometheus.NewDesc("aws_instance_termination_in", "Instance will be terminated in", []string{"instance_id"}, nil),
+		terminationIndicator: prometheus.NewDesc("aws_instance_termination_imminent", "Instance is about to be terminated", append(labels, "instance_action"), nil),
+		terminationTime:      prometheus.NewDesc("aws_instance_termination_in", "Instance will be terminated in", labels, nil),
 	}
 }
 
 func (c *terminationCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.scrapeSuccessful
 	ch <- c.terminationIndicator
 	ch <- c.terminationTime
 
@@ -39,54 +68,38 @@ func (c *terminationCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *terminationCollector) Collect(ch chan<- prometheus.Metric) {
 	log.Info("Fetching termination data from metadata-service")
-	timeout := time.Duration(1 * time.Second)
-	client := http.Client{
-		Timeout: timeout,
-	}
-	idResp, err := client.Get(c.metadataEndpoint + "instance-id")
-	var instanceId string
-	if err != nil {
-		log.Errorf("couldn't parse instance-id from metadata: %s", err.Error())
-		return
-	}
-	if idResp.StatusCode == 404 {
-		log.Errorf("couldn't parse instance-id from metadata: endpoint not found")
-		return
-	}
-	defer idResp.Body.Close()
-	body, _ := ioutil.ReadAll(idResp.Body)
-	instanceId = string(body)
 
-	resp, err := client.Get(c.metadataEndpoint + "spot/instance-action")
+	az, _ := c.getMetadata("placement/availability-zone")
+	hostname, _ := c.getMetadata("hostname")
+	instanceId, _ := c.getMetadata("instance-id")
+	instanceType, _ := c.getMetadata("instance-type")
+
+	action, err := c.getMetadata("spot/instance-action")
 	if err != nil {
 		log.Errorf("Failed to fetch data from metadata service: %s", err)
-		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 0, instanceId)
 		return
 	} else {
-		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 1, instanceId)
 
-		if resp.StatusCode == 404 {
+		if action == "" {
 			log.Debug("instance-action endpoint not found")
-			ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, "", instanceId)
+			ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, az, hostname, instanceId, instanceType, action)
 			return
 		} else {
-			defer resp.Body.Close()
-			body, _ := ioutil.ReadAll(resp.Body)
 
 			var ia = InstanceAction{}
-			err := json.Unmarshal(body, &ia)
+			err = json.Unmarshal([]byte(action), &ia)
 
 			// value may be present but not be a time according to AWS docs,
 			// so parse error is not fatal
 			if err != nil {
 				log.Errorf("Couldn't parse instance-action metadata: %s", err)
-				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, instanceId)
+				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, az, hostname, instanceId, instanceType, "")
 			} else {
 				log.Infof("instance-action endpoint available, termination time: %v", ia.Time)
-				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 1, ia.Action, instanceId)
+				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 1, az, hostname, instanceId, instanceType, ia.Action)
 				delta := ia.Time.Sub(time.Now())
 				if delta.Seconds() > 0 {
-					ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, delta.Seconds(), instanceId)
+					ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, delta.Seconds(), az, hostname, instanceId, instanceType)
 				}
 			}
 		}


### PR DESCRIPTION
- Remove unneeded metric `aws_instance_metadata_service_available`
- Add extra EC2 attributes as labels for metrics (hostname, instance type, AZ)

